### PR TITLE
Random role assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-bot_info.json

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ async def on_ready():
     print('Logged in as')
     print(bot.user.name)
     print('---------------')
-    #await start_tasks()
+    await start_tasks()
 
 def get_server():
     """Get the server object that we are executing the bot in"""
@@ -111,7 +111,6 @@ async def joined(member : discord.Member):
     """Says when a member joined."""
     await bot.say('{0.name} joined in {0.joined_at}'.format(member))
 
-@bot.command()
 async def role_assigner():
     """Assign the 'Employee of the moment' role to one user for a random amount
     of time, and then unassign and pass it on to someone else."""
@@ -121,7 +120,7 @@ async def role_assigner():
     await remove_leftover_roles(server, emp_role)
 
     while True:
-        random_length = random.randint(1,30)
+        random_length = random.randint(1,86400)
         user = get_random_online_user(server)
         await bot.add_roles(user, emp_role)
         await bot.send_message(channel, user.mention + " is now Employee of the Moment!")

--- a/bot.py
+++ b/bot.py
@@ -1,28 +1,69 @@
-import discord, logging, json, re
+import discord, logging, json, re, random, asyncio, time
 from discord.ext import commands
 from tinydb import TinyDB, Query
 from tinydb.operations import delete, increment
 
-description = '''Basic bot used to do fun things on Roy's Boy Toys '''
-bot = commands.Bot(command_prefix='!', description=description)
+bot = commands.Bot(command_prefix='!', description='''Basic bot used to do fun things on Roy's Boy Toys ''')
 db = TinyDB('db.json')
 Database = Query()
 
 bot_info = json.load(open('bot_info.json'))
 token = bot_info['token']
 
+logging.basicConfig(level=logging.INFO)
+
 # Print the starting text
 print('---------------')
 print('Starting RoyBot...')
 print('---------------')
-
-logging.basicConfig(level=logging.INFO)
 
 @bot.event
 async def on_ready():
     print('Logged in as')
     print(bot.user.name)
     print('---------------')
+    #await start_tasks()
+
+def get_server():
+    """Get the server object that we are executing the bot in"""
+    for i in bot.servers:
+        if i.id == bot_info['serverid']:
+            return i
+
+def is_online(user):
+    """Check if a user is online"""
+    if str(user.status) == "online":
+        return True
+    else:
+        return False
+
+def get_random_online_user(server):
+    """Get a random user that is currently online (status = online)"""
+    online_users = []
+    num_users = 0
+    for user in server.members:
+        if is_online(user):
+            num_users += 1
+            online_users.append(user)
+
+    return online_users[random.randint(0, num_users-1)]
+
+async def remove_leftover_roles(server, role):
+    """Sometimes when we start the bot up there might be some users that still
+    have an old role such as 'Employee of the moment'. Here we remove the role
+    from all users before executing role assignments."""
+    for user in server.members:
+        if role in user.roles:
+            await bot.remove_roles(user, role)
+
+async def start_tasks():
+    '''This function will fire and forget a few methods that will run forever'''
+    asyncio.ensure_future(loop_role_assigner())
+
+async def loop_role_assigner():
+    '''Run role assigner forever'''
+    while True:
+        await role_assigner()
 
 @bot.listen()
 async def on_message(message):
@@ -70,4 +111,29 @@ async def joined(member : discord.Member):
     """Says when a member joined."""
     await bot.say('{0.name} joined in {0.joined_at}'.format(member))
 
-bot.run(token)
+@bot.command()
+async def role_assigner():
+    """Assign the 'Employee of the moment' role to one user for a random amount
+    of time, and then unassign and pass it on to someone else."""
+    server = get_server()
+    channel = server.get_channel(bot_info['channelid'])
+    emp_role = discord.utils.get(server.roles, name="Employee of the moment")
+    await remove_leftover_roles(server, emp_role)
+
+    while True:
+        random_length = random.randint(1,30)
+        user = get_random_online_user(server)
+        await bot.add_roles(user, emp_role)
+        await bot.send_message(channel, user.mention + " is now Employee of the Moment!")
+        start_time = time.time()
+        while True:
+            if is_online(user) is False:
+                break
+            elif (time.time() - start_time) < random_length:
+                asyncio.sleep(3)
+            else:
+                break
+        await bot.remove_roles(user, emp_role)
+
+if __name__ == '__main__':
+    bot.run(token)

--- a/bot_info.json
+++ b/bot_info.json
@@ -3,5 +3,7 @@
   "client-secret": "[clientsecret]",
   "token": "[token]",
   "usertag": "[usertag of bot]",
-  "name": "[name]"
+  "name": "[name]",
+  "serverid": "[serverid]",
+  "channelid": "[channelid]"
 }


### PR DESCRIPTION
Added new role assignment functionality:
- starts as soon as bot boots up
- randomly assigns someone the role of "Employee of the moment" for a random time interval of between 1 second and 1 full day
- role only applies to people online
- anyone who has the role and goes offline will surrender the role
- bot will announce new role holder each time